### PR TITLE
Fix GitHub Action deprecated notices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
       id: package
       env:
         REPO: ${{ github.repository }}
-      run: echo ::set-output name=PACKAGE::${REPO##*/}
+      run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
     - name: Set Version
       id: tag


### PR DESCRIPTION
This fixes several deprecated notices caused by the use of `set-output` and `save-output` in GitHub Action workflows.

These were deprecated, and could be removed at any time without notice. GitHub posted an update on July 24th that they still plan on removing these commands but were delaying the removal because of continued high usage.

More can be found about this in the announcement posts:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/