### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/satis-build-on-push.yml
+++ b/.github/workflows/satis-build-on-push.yml
@@ -24,6 +24,7 @@ jobs:
     name: Satis Build
     runs-on: ubuntu-latest
     permissions:
+      actions: write # Required for actions/cache to restore and save caches.
       contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action.
     timeout-minutes: 30
     steps:

--- a/.github/workflows/satis-build-on-push.yml
+++ b/.github/workflows/satis-build-on-push.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-build-on-push.yml
+++ b/.github/workflows/satis-build-on-push.yml
@@ -15,10 +15,16 @@ concurrency:
 env:
   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.TOKEN }}"}}'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   satisBuild:
     name: Satis Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-build-on-webhook.yml
+++ b/.github/workflows/satis-build-on-webhook.yml
@@ -25,6 +25,7 @@ jobs:
     name: Satis Build
     runs-on: ubuntu-latest
     permissions:
+      actions: write # Required by actions/cache to restore and save caches.
       contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action and to create a repository_dispatch event via peter-evans/repository-dispatch.
     timeout-minutes: 30
     steps:

--- a/.github/workflows/satis-build-on-webhook.yml
+++ b/.github/workflows/satis-build-on-webhook.yml
@@ -16,10 +16,16 @@ env:
   VERSION: ${{ github.event.client_payload.version }}
   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.TOKEN }}"}}'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   satis-build:
     name: Satis Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action and to create a repository_dispatch event via peter-evans/repository-dispatch.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-build-on-webhook.yml
+++ b/.github/workflows/satis-build-on-webhook.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to push commits to the gh-pages branch via ad-m/github-push-action and to create a repository_dispatch event via peter-evans/repository-dispatch.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/satis/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

No analysis summary was found in the subagent logs for this repository.


