### PR TITLE
[codex] Use Newfold access token for Satis builds

### DIFF
--- a/.github/workflows/satis-build-on-push.yml
+++ b/.github/workflows/satis-build-on-push.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.TOKEN }}"}}'
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.NEWFOLD_ACCESS_TOKEN }}"}}'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -38,6 +38,8 @@ jobs:
           php-version: '8.1'
           coverage: none
           tools: composer, cs2pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}
 
       - name: PHP version
         run: php --version
@@ -67,7 +69,7 @@ jobs:
           path: ./dist
 
       - name: Run Build
-        run: composer run build
+        run: composer run satis:build
 
       - name: List files
         run: ls -lah ./dist

--- a/.github/workflows/satis-build-on-webhook.yml
+++ b/.github/workflows/satis-build-on-webhook.yml
@@ -14,7 +14,7 @@ env:
   VENDOR: ${{ github.event.client_payload.vendor }}
   PACKAGE: ${{ github.event.client_payload.package }}
   VERSION: ${{ github.event.client_payload.version }}
-  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.TOKEN }}"}}'
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.NEWFOLD_ACCESS_TOKEN }}"}}'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -39,6 +39,8 @@ jobs:
           php-version: '8.1'
           coverage: none
           tools: composer, cs2pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}
 
       - name: PHP version
         run: php --version

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "satis": "vendor/bin/satis",
-        "build": "@php -dmemory_limit=-1 vendor/bin/satis build ./satis.json ./dist"
+        "satis:build": "@php -dmemory_limit=-1 vendor/bin/satis build ./satis.json ./dist"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Updates both Satis build workflows to use the NEWFOLD_ACCESS_TOKEN org secret for Composer GitHub auth, including setup-php's GITHUB_TOKEN input environment, so Composer does not fall back to the repo-scoped GitHub token for private package repos. Also renames the Composer script from build to satis:build and updates the workflow reference to avoid shadowing Composer's built-in build command. Validation: composer validate passes with the existing composer/satis commit-ref warning.