### PR TITLE
Fix invalid JSON in satis.json (remove trailing comma)

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -214,7 +214,7 @@
         {
             "type": "vcs",
             "url": "git@github.com:newfold-labs/wp-plugin-webhostbox.git"
-        },
+        }
     ],
     "require-all": true
 }


### PR DESCRIPTION
## Problem

`satis.json` is currently **invalid JSON** and every satis build has been failing since commit 93e6f3c ("Add new VCS repository to satis.json", 2026-06-23 13:16). That commit added the `wp-plugin-webhostbox` entry but left a **trailing comma** after the last element of the `repositories` array:

```
        {
            "type": "vcs",
            "url": "git@github.com:newfold-labs/wp-plugin-webhostbox.git"
        },        <-- trailing comma, invalid JSON
    ],
```

Build error:
```
"./satis.json" does not contain valid JSON
Parse error on line 217 ... It appears you have an extra trailing comma
```

Because builds fail, **newly tagged module versions are no longer being indexed** in satis (e.g. wp-module-ecommerce 2.3.8).

## Fix

Remove the single trailing comma so the file is valid JSON again. The `wp-plugin-webhostbox` repository entry is **retained** (only the comma is removed). Validated with a JSON parser; 53 repositories intact.

## Impact

Unblocks all satis builds and restores indexing of recent and future module releases.